### PR TITLE
Support single validator in addition to arrays of validators

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ export default {
 };
 ```
 
-`validateSometimes()` takes 2 arguments. The first is a list of validators you want applied to the attribute. The second argument is a callback function which represents the condition. If the condition callback returns `true`, the rules will be added. This callback function will be invoked with the changeset's changes and content. The callback will also be invoked with its `this` value set to an object that has a `get()` method for accessing a property. `this.get(property)` first proxies to the changes and then the underlying content, and has the same semantics as `Ember.get()`.
+`validateSometimes()` takes 2 arguments. The first is a validator or list of validators you want applied to the attribute. The second argument is a callback function which represents the condition. If the condition callback returns `true`, the rules will be added. This callback function will be invoked with the changeset's changes and content. The callback will also be invoked with its `this` value set to an object that has a `get()` method for accessing a property. `this.get(property)` first proxies to the changes and then the underlying content, and has the same semantics as `Ember.get()`.
 
 ```js
 import Changeset from 'ember-changeset';

--- a/addon/validators/sometimes.js
+++ b/addon/validators/sometimes.js
@@ -1,20 +1,22 @@
 import { get } from '@ember/object';
 
-export default function validateSometimes(validators, condition) {
-  return validators.map(function(validator) {
-    return function(key, newValue, oldValue, changes, content) {
-      let thisValue = {
-        get(property) {
-          return get(changes, property) != null
-            ? get(changes, property)
-            : get(content, property);
-        }
-      };
+export default function validateSometimes(validator, condition) {
+  return Array.isArray(validator) ? validator.map(mapValidator) : mapValidator(validator)
+}
 
-      if (condition.call(thisValue, changes, content)) {
-        return validator(key, newValue, oldValue, changes, content);
+function mapValidator(validator) {
+  return function(key, newValue, oldValue, changes, content) {
+    let thisValue = {
+      get(property) {
+        return get(changes, property) != null
+          ? get(changes, property)
+          : get(content, property);
       }
-      return true;
     };
-  });
+
+    if (condition.call(thisValue, changes, content)) {
+      return validator(key, newValue, oldValue, changes, content);
+    }
+    return true;
+  };
 }

--- a/addon/validators/sometimes.js
+++ b/addon/validators/sometimes.js
@@ -2,21 +2,21 @@ import { get } from '@ember/object';
 
 export default function validateSometimes(validator, condition) {
   return Array.isArray(validator) ? validator.map(mapValidator) : mapValidator(validator)
-}
 
-function mapValidator(validator) {
-  return function(key, newValue, oldValue, changes, content) {
-    let thisValue = {
-      get(property) {
-        return get(changes, property) != null
-          ? get(changes, property)
-          : get(content, property);
+  function mapValidator(validator) {
+    return function(key, newValue, oldValue, changes, content) {
+      let thisValue = {
+        get(property) {
+          return get(changes, property) != null
+            ? get(changes, property)
+            : get(content, property);
+        }
+      };
+
+      if (condition.call(thisValue, changes, content)) {
+        return validator(key, newValue, oldValue, changes, content);
       }
+      return true;
     };
-
-    if (condition.call(thisValue, changes, content)) {
-      return validator(key, newValue, oldValue, changes, content);
-    }
-    return true;
-  };
+  }
 }

--- a/tests/unit/validators/sometimes-test.js
+++ b/tests/unit/validators/sometimes-test.js
@@ -7,7 +7,7 @@ import isFunction from './../../helpers/is-function';
 import Changeset from 'ember-changeset';
 
 module('Unit | Validator | sometimes', function() {
-  test('an array of validators is returned', function(assert) {
+  test('an array of validators is returned when given an array', function(assert) {
     let validatorA = function() {};
     let validatorB = function() {};
     let condition = function() {};
@@ -16,6 +16,15 @@ module('Unit | Validator | sometimes', function() {
 
     assert.equal(validators.length, 2);
     assert.ok(validators.every(isFunction));
+  });
+
+  test('an validator function is returned if given a validator', function(assert) {
+    let validatorA = function() {};
+    let condition = function() {};
+
+    let validator = validateSometimes(validatorA, condition);
+
+    assert.ok(isFunction(validator));
   });
 
   test('if the condition returns false, the validators return true', function(assert) {
@@ -89,6 +98,29 @@ module('Unit | Validator | sometimes', function() {
     assert.strictEqual(validatorB.firstCall.args[2], oldValue);
     assert.strictEqual(validatorB.firstCall.args[3], changes);
     assert.strictEqual(validatorB.firstCall.args[4], content);
+  });
+
+  test('single validator is invoked with key, newValue, oldValue, changes, and content', function(assert) {
+    let key = 'name';
+    let newValue = 'Yehuda';
+    let oldValue = 'YK';
+    let changes = {};
+    let content = {};
+
+    let validatorA = sinon.spy();
+    let condition = () => true;
+
+    let validator = validateSometimes(validatorA, condition);
+
+    assert.ok(isFunction(validator));
+
+    validator(key, newValue, oldValue, changes, content);
+
+    assert.strictEqual(validatorA.firstCall.args[0], key);
+    assert.strictEqual(validatorA.firstCall.args[1], newValue);
+    assert.strictEqual(validatorA.firstCall.args[2], oldValue);
+    assert.strictEqual(validatorA.firstCall.args[3], changes);
+    assert.strictEqual(validatorA.firstCall.args[4], content);
   });
 
   test('this.get() when accessing the changes', function(assert) {


### PR DESCRIPTION
Not a necessary feature so please feel free to reject it. Just for consistency with ember-changeset-validators, avoids obvious `validators.map is not a function` exceptions and reduces issues like https://github.com/skaterdav85/ember-changeset-conditional-validations/issues/9 when only one conditional validator is needed. Please squash the commits if you decide to merge.

Cheers