### PR TITLE
Fix .get() for sometimes condition with falsy values

### DIFF
--- a/addon/validators/sometimes.js
+++ b/addon/validators/sometimes.js
@@ -13,9 +13,31 @@ export default function validateSometimes(validator, condition) {
     return function(key, newValue, oldValue, changes, content) {
       let thisValue = {
         get(property) {
-          return get(changes, property) != null
-            ? get(changes, property)
-            : get(content, property);
+          if (property.includes('.')) {
+            let changesValue = get(changes, property);
+            if (typeof changesValue !== 'undefined') {
+              return changesValue;
+            }
+
+            // Check if the `changes` value is explicitly undefined,
+            // or if it's not present at all.
+            let pathSegments = property.split('.');
+            let propName = pathSegments.pop();
+            let objPath = pathSegments.join('.');
+
+            let obj = get(changes, objPath);
+            if (obj && obj.hasOwnProperty && obj.hasOwnProperty(propName)) {
+              return changesValue;
+            }
+
+            return get(content, property);
+          }
+
+          if (changes.hasOwnProperty(property)) {
+            return get(changes, property);
+          } else {
+            return get(content, property);
+          }
         }
       };
 

--- a/tests/unit/validators/sometimes-test.js
+++ b/tests/unit/validators/sometimes-test.js
@@ -215,7 +215,7 @@ module('Unit | Validator | sometimes', function() {
     assert.notOk(changeset.get('isValid'));
   });
 
-  test('this.get() when setting the key to false', function(assert) {
+  test('this.get() when setting the value to false', function(assert) {
     let Validations = {
       hasCreditCard: validatePresence(true),
       creditCardNumber: validateSometimes([
@@ -235,5 +235,102 @@ module('Unit | Validator | sometimes', function() {
     changeset.validate();
 
     assert.ok(changeset.get('isValid'), 'valid');
+  });
+
+  test('this.get() when setting the value to null', function(assert) {
+    let Validations = {
+      creditCardNumber: validateSometimes([
+        validatePresence(true),
+        validateLength({ is: 16 })
+      ], function () {
+        return this.get('creditCardDetails');
+      })
+    };
+
+    let changeset = new Changeset({
+      creditCardDetails: {
+        number: '1234567890123456'
+      }
+    }, lookupValidator(Validations), Validations);
+
+    changeset.set('creditCardDetails', null);
+    changeset.set('creditCardNumber', '12');
+    changeset.validate();
+
+    assert.ok(changeset.get('isValid'), 'valid');
+  });
+
+  test('this.get() when setting the value to undefined', function(assert) {
+    let Validations = {
+      creditCardNumber: validateSometimes([
+        validatePresence(true),
+        validateLength({ is: 16 })
+      ], function () {
+        return this.get('creditCardDetails');
+      })
+    };
+
+    let changeset = new Changeset({
+      creditCardDetails: {
+        number: '1234567890123456'
+      }
+    }, lookupValidator(Validations), Validations);
+
+    changeset.set('creditCardDetails', undefined);
+    changeset.set('creditCardNumber', '12');
+    changeset.validate();
+
+    assert.ok(changeset.get('isValid'), 'valid');
+  });
+
+  test('this.get() when setting a property path to falsy values', function(assert) {
+    let Validations = {
+      creditCardNumber: validateSometimes([
+        validatePresence(true),
+        validateLength({ is: 16 })
+      ], function() {
+        return this.get('paymentMethod.isCreditCard');
+      })
+    };
+
+    let changeset = new Changeset({
+      paymentDetails: {
+        methodInfo: {
+          isCreditCard: true
+        }
+      },
+      creditCardNumber: 12
+    }, lookupValidator(Validations), Validations);
+
+    changeset.validate();
+    assert.ok(changeset.get('isValid'));
+
+    changeset.set('paymentDetails.methodInfo.isCreditCard', false);
+    changeset.validate();
+    assert.ok(changeset.get('isValid'));
+
+    changeset.set('paymentDetails.methodInfo.isCreditCard', null);
+    changeset.validate();
+    assert.ok(changeset.get('isValid'));
+
+    changeset.set('paymentDetails.methodInfo.isCreditCard', undefined);
+    changeset.validate();
+    assert.ok(changeset.get('isValid'));
+
+    changeset.set('paymentDetails.methodInfo', null);
+    changeset.validate();
+    assert.ok(changeset.get('isValid'));
+
+    changeset.set('paymentDetails.methodInfo', undefined);
+    changeset.validate();
+    assert.ok(changeset.get('isValid'));
+
+    changeset.set('paymentDetails', null);
+    changeset.validate();
+    assert.ok(changeset.get('isValid'));
+
+    changeset.set('paymentDetails', undefined);
+    changeset.validate();
+    assert.ok(changeset.get('isValid'));
   });
 });


### PR DESCRIPTION
Following on from this issue reported in https://github.com/skaterdav85/ember-changeset-conditional-validations/issues/10 and the fix provided in https://github.com/skaterdav85/ember-changeset-conditional-validations/pull/11, this PR fixes the issue highlighted in this [comment](https://github.com/skaterdav85/ember-changeset-conditional-validations/pull/11#discussion_r200844584) where the fix for `false` values not working as expected does not resolve the issue for other falsy values like `null` and `undefined`.

I've attempted to handle [nested property paths](https://github.com/skaterdav85/ember-changeset-conditional-validations/compare/master...andrewpye:fix/falsy-value-handling-in-sometimes?expand=1#diff-484b11ab8de2d9541f64004d56be2e40R16) as part of this, but the spec is definitely open to discussion 😉 